### PR TITLE
digging into dependency tracking for dev dependencies

### DIFF
--- a/cargo-quickbuild/src/archive.rs
+++ b/cargo-quickbuild/src/archive.rs
@@ -212,7 +212,7 @@ fn insert_timestamp<R: Read>(
     mtime: FileTime,
 ) -> Result<(), anyhow::Error> {
     let path = file.path()?.clone().into_owned();
-    println!("have high-res timesamp for {path:?}: {mtime}");
+    log::debug!("have high-res timesamp for {path:?}: {mtime}");
 
     match file_timestamps.entry(path) {
         btree_map::Entry::Vacant(entry) => {

--- a/cargo-quickbuild/src/deps.rs
+++ b/cargo-quickbuild/src/deps.rs
@@ -1,0 +1,32 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    ops::Deref,
+};
+
+use cargo::core::compiler::{unit_graph::UnitDep, Unit};
+
+pub trait UnitGraphExt {
+    /// Breadth first search to find a parent-child relationship. I have no idea which search order will be fastest. This was just the order that popped into my head first.
+    fn has_dependency(&self, maybe_parent: &Unit, maybe_child: &Unit) -> bool;
+    fn find_by_name(&self, name: &'static str) -> Box<dyn Iterator<Item = &'_ Unit> + '_>;
+}
+
+impl UnitGraphExt for HashMap<Unit, Vec<UnitDep>> {
+    fn has_dependency(&self, maybe_parent: &Unit, maybe_child: &Unit) -> bool {
+        let mut haystack: VecDeque<&Unit> = Default::default();
+        haystack.push_back(maybe_parent);
+        while let Some(current) = haystack.pop_front() {
+            if current == maybe_child {
+                return true;
+            }
+            haystack.extend(self.get(current).unwrap().iter().map(|dep| &dep.unit))
+        }
+        false
+    }
+    fn find_by_name(&self, name: &'static str) -> Box<dyn Iterator<Item = &'_ Unit> + '_> {
+        Box::new(
+            self.keys()
+                .filter(move |unit| (*unit).deref().pkg.name() == name),
+        )
+    }
+}

--- a/cargo-quickbuild/src/deps.rs
+++ b/cargo-quickbuild/src/deps.rs
@@ -3,7 +3,10 @@ use std::{
     ops::Deref,
 };
 
-use cargo::core::compiler::{unit_graph::UnitDep, Unit};
+use cargo::{
+    core::compiler::{unit_graph::UnitDep, Unit},
+    util::interning::InternedString,
+};
 
 pub trait UnitGraphExt {
     /// Breadth first search to find a parent-child relationship. I have no idea which search order will be fastest. This was just the order that popped into my head first.
@@ -28,5 +31,30 @@ impl UnitGraphExt for HashMap<Unit, Vec<UnitDep>> {
             self.keys()
                 .filter(move |unit| (*unit).deref().pkg.name() == name),
         )
+    }
+}
+
+/// Helpers for debugging vecs of Unit
+pub trait UnitNames {
+    fn unit_names(&self) -> Vec<InternedString>;
+    fn unit_names_and_deps(&self) -> Vec<(InternedString, Vec<InternedString>)>;
+}
+
+impl UnitNames for Vec<(&Unit, &Vec<UnitDep>)> {
+    fn unit_names(&self) -> Vec<InternedString> {
+        self.iter()
+            .map(|(unit, _)| (*unit).deref().pkg.name())
+            .collect()
+    }
+
+    fn unit_names_and_deps(&self) -> Vec<(InternedString, Vec<InternedString>)> {
+        self.iter()
+            .map(|(unit, deps)| {
+                (
+                    (*unit).deref().pkg.name(),
+                    deps.iter().map(|dep| dep.unit.deref().pkg.name()).collect(),
+                )
+            })
+            .collect()
     }
 }

--- a/cargo-quickbuild/src/deps.rs
+++ b/cargo-quickbuild/src/deps.rs
@@ -11,7 +11,7 @@ use cargo::{
 pub trait UnitGraphExt {
     /// Breadth first search to find a parent-child relationship. I have no idea which search order will be fastest. This was just the order that popped into my head first.
     fn has_dependency(&self, maybe_parent: &Unit, maybe_child: &Unit) -> bool;
-    fn find_by_name(&self, name: &'static str) -> Box<dyn Iterator<Item = &'_ Unit> + '_>;
+    fn filter_by_name(&self, name: &'static str) -> Box<dyn Iterator<Item = &'_ Unit> + '_>;
 }
 
 impl UnitGraphExt for HashMap<Unit, Vec<UnitDep>> {
@@ -26,7 +26,7 @@ impl UnitGraphExt for HashMap<Unit, Vec<UnitDep>> {
         }
         false
     }
-    fn find_by_name(&self, name: &'static str) -> Box<dyn Iterator<Item = &'_ Unit> + '_> {
+    fn filter_by_name(&self, name: &'static str) -> Box<dyn Iterator<Item = &'_ Unit> + '_> {
         Box::new(
             self.keys()
                 .filter(move |unit| (*unit).deref().pkg.name() == name),

--- a/cargo-quickbuild/src/main.rs
+++ b/cargo-quickbuild/src/main.rs
@@ -3,6 +3,7 @@ mod deps;
 mod pax;
 mod stats;
 mod std_ext;
+mod unit_types;
 
 use std::collections::BTreeMap;
 use std::fmt::Write as _;

--- a/cargo-quickbuild/src/main.rs
+++ b/cargo-quickbuild/src/main.rs
@@ -61,7 +61,7 @@ fn unpack_or_build_packages(tarball_dir: &Path) -> Result<()> {
         // HACK: only build curl-sys + deps, to repo an issue more quickly
         .filter(|(unit, _)| {
             bcx.unit_graph
-                .find_by_name("curl-sys")
+                .filter_by_name("curl-sys")
                 .any(|curl| bcx.unit_graph.has_dependency(curl, unit))
         })
         .collect();

--- a/cargo-quickbuild/src/unit_types.rs
+++ b/cargo-quickbuild/src/unit_types.rs
@@ -1,0 +1,68 @@
+#[cfg(test)]
+mod tests {
+    use cargo::core::{compiler::CompileKind, TargetKind};
+
+    use super::super::*;
+    #[test]
+    fn libnghttp2_sys_structure() -> Result<()> {
+        let config = Config::default()?;
+        let ws = Workspace::new(&Path::new("Cargo.toml").canonicalize()?, &config)?;
+        let options = CompileOptions::new(&config, CompileMode::Build)?;
+        let interner = UnitInterner::new();
+        let bcx = create_bcx(&ws, &options, &interner)?;
+
+        let [compile_build_script_unit]: [_; 1] = bcx
+            .unit_graph
+            .find_by_name("libnghttp2-sys")
+            // FIXME: turn this into an extension method on Unit or something.
+            .filter(|unit| {
+                unit.target.name() == "build-script-build"
+                    && unit
+                        .target
+                        .src_path()
+                        .path()
+                        .map(|path| path.ends_with("build.rs"))
+                        .unwrap_or_default()
+                    && unit.mode == CompileMode::Build
+            })
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+
+        let [run_build_script_unit]: [_; 1] = bcx
+            .unit_graph
+            .find_by_name("libnghttp2-sys")
+            // FIXME: turn this into an extension method on Unit or something.
+            .filter(|unit| {
+                unit.target.name() == "build-script-build"
+                    && unit
+                        .target
+                        .src_path()
+                        .path()
+                        .map(|path| path.ends_with("build.rs"))
+                        .unwrap_or_default()
+                    && unit.mode == CompileMode::RunCustomBuild
+            })
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+
+        let [compile_lib_script_unit]: [_; 1] = bcx
+            .unit_graph
+            .find_by_name("libnghttp2-sys")
+            // FIXME: turn this into an extension method on Unit or something.
+            .filter(|unit| {
+                unit.target.name() == "libnghttp2-sys"
+                    && matches!(unit.target.kind(), TargetKind::Lib(_))
+                    && unit.mode == CompileMode::Build
+            })
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+
+        assert_ne!(compile_build_script_unit, run_build_script_unit);
+        assert_ne!(run_build_script_unit, compile_lib_script_unit);
+        assert_ne!(compile_lib_script_unit, compile_build_script_unit);
+        Ok(())
+    }
+}

--- a/cargo-quickbuild/src/unit_types.rs
+++ b/cargo-quickbuild/src/unit_types.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use cargo::core::{compiler::CompileKind, TargetKind};
+    use cargo::core::TargetKind;
 
     use super::super::*;
     #[test]
@@ -13,7 +13,7 @@ mod tests {
 
         let [compile_build_script_unit]: [_; 1] = bcx
             .unit_graph
-            .find_by_name("libnghttp2-sys")
+            .filter_by_name("libnghttp2-sys")
             // FIXME: turn this into an extension method on Unit or something.
             .filter(|unit| {
                 unit.target.name() == "build-script-build"
@@ -31,7 +31,7 @@ mod tests {
 
         let [run_build_script_unit]: [_; 1] = bcx
             .unit_graph
-            .find_by_name("libnghttp2-sys")
+            .filter_by_name("libnghttp2-sys")
             // FIXME: turn this into an extension method on Unit or something.
             .filter(|unit| {
                 unit.target.name() == "build-script-build"
@@ -49,7 +49,7 @@ mod tests {
 
         let [compile_lib_script_unit]: [_; 1] = bcx
             .unit_graph
-            .find_by_name("libnghttp2-sys")
+            .filter_by_name("libnghttp2-sys")
             // FIXME: turn this into an extension method on Unit or something.
             .filter(|unit| {
                 unit.target.name() == "libnghttp2-sys"


### PR DESCRIPTION
The work in this PR got me to the realisation that I am using the wrong data types

> Hrm. It looks like I'm doing everything in terms of BuildContext and units, whereas cargo tree does things in terms of Resolve and Dependency. This explains why I was getting confused by build.rs scripts, and was completely incapable of finding a way to separate build deps from non build deps.
> 
> In order to proceed with handling build deps, I will need to take a step back and rewrite everything in terms of the dependency resolver. Probably start by creating a WorkspaceResolve rather than a BuildContext.
> 
-- https://github.com/cargo-quick/cargo-quick/issues/14#issuecomment-1201382692

Merging and cutting a new PR to do the above refactor